### PR TITLE
Remove dependency to through2

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,8 +39,7 @@
     "fancy-log": "^1.3.3",
     "plugin-error": "^1.0.1",
     "source-map": "^0.7.3",
-    "strip-ansi": "^6.0.0",
-    "through2": "^4.0.2"
+    "strip-ansi": "^6.0.0"
   },
   "devDependencies": {
     "eslint": "^6.8.0",

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const PluginError = require('plugin-error');
-const through = require('through2');
+const { Transform } = require("stream");
 const {formatters, lint} = require('stylelint');
 
 const applySourcemap = require('./apply-sourcemap');
@@ -175,7 +175,14 @@ module.exports = function gulpStylelint(options) {
       });
   }
 
-  return through.obj(onFile, onStreamEnd).resume();
+  const stream = new Transform({
+    objectMode: true,
+    highWaterMark: 16,
+    transform: onFile,
+    flush: onStreamEnd
+  });
+
+  return stream.resume();
 };
 
 /**


### PR DESCRIPTION
This PR removes a dependency to through2 because it uses readable-stream which is an outdated version of node-stream and yet one more dependency.

Replaced by the standard node stream API

I didn't update the package-lock because it would most probably conflict with my other PR