### PR TITLE
Update to stylelint 16

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ronilaukkarinen/gulp-stylelint",
-  "version": "14.1.2",
+  "version": "15.0.0",
   "description": "Gulp plugin for running Stylelint results through various reporters.",
   "main": "src/index.js",
   "files": [
@@ -29,10 +29,10 @@
   },
   "homepage": "https://github.com/ronilaukkarinen/gulp-stylelint",
   "engines": {
-    "node": "^12.20.0 || ^14.13.1 || >=15.14.0 || >=16.0.0"
+    "node": ">=18.12.0"
   },
   "peerDependencies": {
-    "stylelint": "10 - 15"
+    "stylelint": "16"
   },
   "dependencies": {
     "@jridgewell/trace-mapping": "^0.3.17",
@@ -55,8 +55,8 @@
     "jest": "^29.4.2",
     "postcss": "^8.4.31",
     "sinon": "^15.0.1",
-    "stylelint": "^15.11.0",
-    "stylelint-config-standard": "^34.0.0",
+    "stylelint": "^16.1.0",
+    "stylelint-config-standard": "^36.0.0",
     "tape": "^5.6.3"
   },
   "eslintConfig": {

--- a/src/index.js
+++ b/src/index.js
@@ -102,8 +102,8 @@ module.exports = function gulpStylelint(options) {
           lintResult
       )
       .then(lintResult => {
-        if (lintOptions.fix && lintResult.output) {
-          file.contents = Buffer.from(lintResult.output);
+        if (lintOptions.fix && lintResult.code) {
+          file.contents = Buffer.from(lintResult.code);
         }
 
         done(null, file);

--- a/src/reporter-factory.js
+++ b/src/reporter-factory.js
@@ -12,25 +12,23 @@ const writer = require('./writer');
  * @return {Function} Reporter.
  */
 module.exports = function reporterFactory(config = {}, options = {}) {
-
-  /**
-   * Formatter for stylelint results.
-   *
-   * User has a choice of passing a custom formatter function,
-   * or a name of formatter bundled with stylelint by default.
-   *
-   * @type {Function}
-   */
-  const formatter = typeof config.formatter === 'string' ?
-    formatters[config.formatter] :
-    config.formatter;
-
   /**
    * Reporter.
    * @param {[Object]} results - Array of stylelint results.
    * @return {Promise} Resolved when writer and logger are done.
    */
-  return function reporter(results) {
+  return async function reporter(results) {
+    /**
+     * Formatter for stylelint results.
+     *
+     * User has a choice of passing a custom formatter function,
+     * or a name of formatter bundled with stylelint by default.
+     *
+     * @type {Function}
+     */
+    const formatter = typeof config.formatter === 'string' ?
+      await formatters[config.formatter] :
+      config.formatter;
 
     /**
      * Async tasks performed by the reporter.

--- a/test/fixtures/basic.css
+++ b/test/fixtures/basic.css
@@ -1,3 +1,3 @@
 .foo {
-  color: #f00;
+  color: #ff0000aa;
 }

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -48,7 +48,7 @@ test('should emit an error when linter complains', t => {
   gulp
     .src(fixtures('invalid.css'))
     .pipe(gulpStylelint({config: {rules: {
-      'color-hex-case': 'lower'
+      'color-hex-length': 'long'
     }}}))
     .on('error', () => t.pass('error has been emitted correctly'));
 });
@@ -58,7 +58,7 @@ test('should ignore file', t => {
   gulp
     .src([fixtures('basic.css'), fixtures('invalid.css')])
     .pipe(gulpStylelint({
-      config: {rules: {'color-hex-case': 'lower'}},
+      config: {rules: {'color-hex-length': 'long'}},
       ignorePath: fixtures('ignore')
     }))
     .on('finish', () => t.pass('no error emitted'));
@@ -71,21 +71,21 @@ test('should fix the file without emitting errors', t => {
     .pipe(gulpSourcemaps.init())
     .pipe(gulpStylelint({
       fix: true,
-      config: {rules: {'color-hex-case': 'lower'}}
+      config: {rules: {'color-hex-length': 'long'}}
     }))
     .pipe(gulp.dest(path.resolve(__dirname, '../tmp')))
     .on('error', error => t.fail(`error ${error} has been emitted`))
     .on('finish', () => {
       t.equal(
         fs.readFileSync(path.resolve(__dirname, '../tmp/invalid.css'), 'utf8'),
-        '.foo {\n  color: #fff;\n}\n',
+        '.foo {\n  color: #FFFFFF;\n}\n',
         'report file has fixed contents'
       );
       t.pass('no error emitted');
     });
 });
 
-test('should expose an object with stylelint formatter functions', t => {
+test('should expose an object with stylelint formatter promises', t => {
   t.plan(2);
   t.equal(typeof gulpStylelint.formatters, 'object', 'formatters property is an object');
 
@@ -93,5 +93,5 @@ test('should expose an object with stylelint formatter functions', t => {
     .keys(gulpStylelint.formatters)
     .map(fName => gulpStylelint.formatters[fName]);
 
-  t.true(formatters.every(f => typeof f === 'function'), 'all formatters are functions');
+  t.true(formatters.every(f => typeof f.then === 'function'), 'all formatters are promises');
 });


### PR DESCRIPTION
Stylelint 16 had quite a few changes
This includes what appears to be the minimally required changes for v16 compatibility.
Note that CommonJS is [deprecated](https://stylelint.io/migration-guide/to-16/#deprecated-commonjs-api) in stylelint 16.  This does not update gulp-stylelint to ESM, but that will need to happen before v17.
Deprecation warnings related to CommonJS will be logged to the console.  You can disable these via the `quietDeprecationWarnings` flag, but this seems overly aggressive to me.

The following changes were made in order for v16 compatibility:
- Bump this project version to v15.0.0
- Update node engine to 18.12.0+
  - https://stylelint.io/migration-guide/to-16/#removed-support-for-nodejs-less-than-18120
- Update stylelint-config-standard to a compatible current version
- Replace `lintResult.output` with `lintResult.code`
  - https://stylelint.io/migration-guide/to-16/#changed-nodejs-api-returned-resolved-object
- Formatters are now promises; updated to use an async function and await the promise resolution
  - https://stylelint.io/migration-guide/to-16/#changed-nodejs-api-stylelintformatters-object
- `color-hex-case` rule was previously deprecated and has been removed in v16.   Updated unit tests to utilize `color-hex-length` rule instead.
  - https://stylelint.io/migration-guide/to-15#deprecated-stylistic-rules

fixes #10